### PR TITLE
fix: check separate if post is empty in case of deleted post

### DIFF
--- a/src/Twig/Post.php
+++ b/src/Twig/Post.php
@@ -38,8 +38,10 @@ class Post {
 			$this->post = $post;
 		} elseif ( is_numeric( $post ) ) {
 			$this->post = get_post( $post );
-		} else {
-			$this->post     = new WP_Post( (object) [] );
+		}
+
+		if ( empty( $this->post ) ) {
+			$this->post = new WP_Post( (object) [] );
 			$this->post->ID = 0;
 		}
 


### PR DESCRIPTION
Do the empty check after, because deleted post ID is numeric, so the else will not be reached in the old situation and then null is passed as second arg to the new Meta and that causes a fatal.